### PR TITLE
fix(security): remove compromised axios 1.14.1 from lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,14 +35,13 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.1.tgz",
-      "integrity": "sha512-vF/aB4vrIzLyOb2TB9gpuE8gusNHpZqk2ZZcAqSnRjW5IcY7tFSBEurD2tbakohj0Rw5xMHYwjSqOGSfr0iewA==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
+      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "plain-crypto-js": "^4.2.1",
         "proxy-from-env": "^2.1.0"
       }
     },
@@ -360,13 +359,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
-    "node_modules/plain-crypto-js": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/plain-crypto-js/-/plain-crypto-js-4.2.1.tgz",
-      "integrity": "sha512-Wv41p4/aEMq03JjDqi0JxPYT4aoMbbQMSM8ur4QkjvjGEeuYvI7rGkqLcOZ7K1iThQGvpNvJnxRWcNodCNuEEQ==",
-      "hasInstallScript": true,
       "license": "MIT"
     },
     "node_modules/proxy-from-env": {


### PR DESCRIPTION
## Summary

- Regenerated `package-lock.json` to remove the compromised axios 1.14.1 and its malicious dependency `plain-crypto-js@4.2.1`
- Lockfile now resolves to clean axios 1.14.0
- No code changes — lockfile-only fix

## Context

On 2026-03-31, malicious axios versions (1.14.1, 0.30.4) were published via a hijacked maintainer account. These versions pulled in `plain-crypto-js@4.2.1`, a package that drops a cross-platform RAT on install. The malicious versions have since been yanked from npm.

The `node_modules` directory is gitignored and was never committed, so no malicious code was ever present in the repository tree — only a reference in the lockfile.

## Test plan

- [x] Verify `plain-crypto-js` no longer appears in `package-lock.json`
- [x] Verify axios resolves to 1.14.0 (clean version)
- [x] `npm install` completes with 0 vulnerabilities
- [x] `npm audit` passes clean

Closes #52